### PR TITLE
新的natRefObjImpl，现在无法直接使用new创建对象以及使用delete删除对象，只能使用make_ref或者直接构造来创建实例

### DIFF
--- a/NatsuLib/natBinary.h
+++ b/NatsuLib/natBinary.h
@@ -30,7 +30,7 @@ namespace NatsuLib
 	///	@warning	不适用于多个成员的结构体
 	////////////////////////////////////////////////////////////////////////////////
 	class natBinaryReader
-		: public natRefObjImpl<natRefObj>
+		: public natRefObjImpl<natBinaryReader, natRefObj>
 	{
 	public:
 		explicit natBinaryReader(natRefPointer<natStream> stream, Environment::Endianness endianness = Environment::GetEndianness()) noexcept;
@@ -81,7 +81,7 @@ namespace NatsuLib
 	///	@warning	不适用于多个成员的结构体
 	////////////////////////////////////////////////////////////////////////////////
 	class natBinaryWriter
-		: public natRefObjImpl<natRefObj>
+		: public natRefObjImpl<natBinaryWriter, natRefObj>
 	{
 	public:
 		explicit natBinaryWriter(natRefPointer<natStream> stream, Environment::Endianness endianness = Environment::GetEndianness()) noexcept;

--- a/NatsuLib/natCompression.cpp
+++ b/NatsuLib/natCompression.cpp
@@ -509,6 +509,7 @@ natZipArchive::~natZipArchive()
 natRefPointer<natZipArchive::ZipEntry> natZipArchive::CreateEntry(nStrView entryName)
 {
 	auto entry = new ZipEntry(this, entryName);
+	entry->SetDeleter();
 	const natRefPointer<ZipEntry> pEntry{ entry };
 	SafeRelease(entry);
 	m_EntriesMap.emplace(pEntry->m_CentralDirectoryFileHeader.Filename, pEntry);
@@ -1209,6 +1210,7 @@ void natZipArchive::readCentralDirectory()
 	while (header.Read(m_Reader, saveExtraFieldsAndComments, m_Encoding))
 	{
 		auto entry = new ZipEntry(this, header);
+		entry->SetDeleter();
 		auto pEntry = natRefPointer<ZipEntry>{ entry };
 		SafeRelease(entry);
 		addEntry(std::move(pEntry));

--- a/NatsuLib/natCompression.h
+++ b/NatsuLib/natCompression.h
@@ -20,7 +20,7 @@ namespace NatsuLib
 	///	@note	不会进行缓存，如果提供的流不符合条件请自行进行缓存
 	////////////////////////////////////////////////////////////////////////////////
 	class natZipArchive
-		: public natRefObjImpl<natRefObj>
+		: public natRefObjImpl<natZipArchive, natRefObj>
 	{
 	public:
 		class ZipEntry;
@@ -226,7 +226,7 @@ namespace NatsuLib
 		///	@brief	Zip压缩文档入口
 		////////////////////////////////////////////////////////////////////////////////
 		class ZipEntry
-			: public natRefObjImpl<natRefObj>
+			: public natRefObjImpl<ZipEntry, natRefObj>
 		{
 			friend class natZipArchive;
 		public:
@@ -285,7 +285,7 @@ namespace NatsuLib
 			void writeLocalFileHeaderAndData();
 
 			class ZipEntryWriteStream final
-				: public natRefObjImpl<natStream>
+				: public natRefObjImpl<ZipEntryWriteStream, natStream>
 			{
 			public:
 				ZipEntryWriteStream(ZipEntry& entry, natRefPointer<natCrc32Stream> crc32Stream, std::function<void()> finishCallback = {});
@@ -315,7 +315,7 @@ namespace NatsuLib
 			};
 
 			class DisposeCallbackStream final
-				: public natRefObjImpl<natStream>
+				: public natRefObjImpl<DisposeCallbackStream, natStream>
 			{
 			public:
 				explicit DisposeCallbackStream(natRefPointer<natStream> internalStream, std::function<void()> disposeCallback = {});

--- a/NatsuLib/natCompressionStream.h
+++ b/NatsuLib/natCompressionStream.h
@@ -10,7 +10,7 @@ namespace NatsuLib
 	}
 
 	class natDeflateStream
-		: public natRefObjImpl<natStream>, public nonmovable
+		: public natRefObjImpl<natDeflateStream, natStream>, public nonmovable
 	{
 		enum : size_t
 		{
@@ -54,7 +54,7 @@ namespace NatsuLib
 	};
 
 	class natCrc32Stream
-		: public natRefObjImpl<natStream>
+		: public natRefObjImpl<natCrc32Stream, natStream>
 	{
 	public:
 		explicit natCrc32Stream(natRefPointer<natStream> stream);

--- a/NatsuLib/natLocalFileScheme.h
+++ b/NatsuLib/natLocalFileScheme.h
@@ -4,7 +4,7 @@
 namespace NatsuLib
 {
 	class LocalFileScheme final
-		: public natRefObjImpl<IScheme>
+		: public natRefObjImpl<LocalFileScheme, IScheme>
 	{
 	public:
 		nStrView GetSchemeName() const noexcept override;
@@ -12,7 +12,7 @@ namespace NatsuLib
 	};
 
 	class LocalFileRequest final
-		: public natRefObjImpl<IRequest>
+		: public natRefObjImpl<LocalFileRequest, IRequest>
 	{
 	public:
 		explicit LocalFileRequest(Uri const& uri);
@@ -40,7 +40,7 @@ namespace NatsuLib
 	};
 
 	class LocalFileResponse final
-		: public natRefObjImpl<IResponse>
+		: public natRefObjImpl<LocalFileResponse, IResponse>
 	{
 	public:
 		explicit LocalFileResponse(natRefPointer<natFileStream> stream);

--- a/NatsuLib/natNamedPipe.h
+++ b/NatsuLib/natNamedPipe.h
@@ -31,7 +31,7 @@ namespace NatsuLib
 	};
 
 	class natNamedPipeServerStream
-		: public natRefObjImpl<natStream>
+		: public natRefObjImpl<natNamedPipeServerStream, natStream>
 	{
 	public:
 #ifdef _WIN32
@@ -85,7 +85,7 @@ namespace NatsuLib
 	};
 
 	class natNamedPipeClientStream
-		: public natRefObjImpl<natStream>
+		: public natRefObjImpl<natNamedPipeClientStream, natStream>
 	{
 	public:
 		enum TimeOut : nuInt

--- a/NatsuLib/natStream.cpp
+++ b/NatsuLib/natStream.cpp
@@ -1266,7 +1266,7 @@ natMemoryStream::natMemoryStream(nLen Length, nBool bReadable, nBool bWritable, 
 }
 
 natMemoryStream::natMemoryStream(natMemoryStream const& other)
-	: natRefObjImpl<natStream>(), m_pData(), m_Size(), m_Capacity(), m_CurPos(), m_bReadable(), m_bWritable(), m_AutoResize()
+	: m_pData(), m_Size(), m_Capacity(), m_CurPos(), m_bReadable(), m_bWritable(), m_AutoResize()
 {
 	*this = other;
 }

--- a/NatsuLib/natStream.h
+++ b/NatsuLib/natStream.h
@@ -124,7 +124,7 @@ namespace NatsuLib
 	///	@brief	NatsuLib内存流实现
 	////////////////////////////////////////////////////////////////////////////////
 	class natMemoryStream
-		: public natRefObjImpl<natStream>
+		: public natRefObjImpl<natMemoryStream, natStream>
 	{
 	public:
 		natMemoryStream(ncData pData, nLen Length, nBool bReadable, nBool bWritable, nBool autoResize);
@@ -180,7 +180,7 @@ namespace NatsuLib
 	};
 
 	class natExternMemoryStream
-		: public natRefObjImpl<natStream>
+		: public natRefObjImpl<natExternMemoryStream, natStream>
 	{
 	public:
 		template <size_t N>
@@ -228,7 +228,7 @@ namespace NatsuLib
 	///	@brief	NatsuLib文件流实现
 	////////////////////////////////////////////////////////////////////////////////
 	class natFileStream
-		: public natRefObjImpl<natStream>, public nonmovable
+		: public natRefObjImpl<natFileStream, natStream>, public nonmovable
 	{
 	public:
 #ifdef _WIN32
@@ -291,7 +291,7 @@ namespace NatsuLib
 	};
 
 	class natSubStream
-		: public natRefObjImpl<natStream>
+		: public natRefObjImpl<natSubStream, natStream>
 	{
 	public:
 		natSubStream(natRefPointer<natStream> stream, nLen startPosition, nLen endPosition);
@@ -327,7 +327,7 @@ namespace NatsuLib
 	};
 
 	class natStdStream
-		: public natRefObjImpl<natStream>, public nonmovable
+		: public natRefObjImpl<natStdStream, natStream>, public nonmovable
 	{
 	public:
 		enum StdStreamType

--- a/NatsuLib/natStreamHelper.h
+++ b/NatsuLib/natStreamHelper.h
@@ -11,7 +11,7 @@ namespace NatsuLib
 {
 	template <StringType encoding>
 	class natStreamReader final
-		: public natRefObjImpl<TextReader<encoding>>
+		: public natRefObjImpl<natStreamReader<encoding>, TextReader<encoding>>
 	{
 	public:
 		typedef typename StringEncodingTrait<encoding>::CharType CharType;
@@ -126,7 +126,7 @@ namespace NatsuLib
 
 	template <StringType encoding>
 	class natStreamWriter final
-		: public natRefObjImpl<TextWriter<encoding>>
+		: public natRefObjImpl<natStreamWriter<encoding>, TextWriter<encoding>>
 	{
 	public:
 		explicit natStreamWriter(natStream* pStream) noexcept

--- a/NatsuLib/natStringUtil.h
+++ b/NatsuLib/natStringUtil.h
@@ -36,7 +36,7 @@ namespace NatsuLib
 				template <typename T, typename F>
 				[[noreturn]] static void visit(T&&, size_t, F)
 				{
-					nat_Throw(natException, "Out of range."_nv);
+					nat_Throw(OutOfRange, "Out of range."_nv);
 				}
 			};
 
@@ -402,7 +402,7 @@ namespace NatsuLib
 #ifdef _WIN32
 			return { AnsiStringView{ ss.str().c_str() } };
 #else
-			return { ss.str().c_str() };
+			return { U8StringView{ ss.str().c_str() } };
 #endif
 		}
 

--- a/Test/main.cpp
+++ b/Test/main.cpp
@@ -150,7 +150,7 @@ int main()
 		}
 
 		{
-			struct RefTest : natRefObjImpl<natRefObj>
+			struct RefTest : natRefObjImpl<RefTest, natRefObj>
 			{
 				RefTest()
 				{
@@ -222,7 +222,7 @@ int main()
 
 		{
 			struct Integer
-				: natRefObjImpl<RelationalOperator::IComparable<int>>
+				: natRefObjImpl<Integer, RelationalOperator::IComparable<int>>
 			{
 				nInt CompareTo(int const& other) const override
 				{


### PR DESCRIPTION
同时可以在运行期决定Deleter